### PR TITLE
Fix the compilation error without MPI library

### DIFF
--- a/pll/genericParallelization.c
+++ b/pll/genericParallelization.c
@@ -42,7 +42,10 @@
 #include "genericParallelization.h"
 #include "pllInternal.h"
 #include "pll.h"
+
+#ifdef _IQTREE_MPI
 #include <mpi.h>
+#endif
 
 /** @file genericParallelization.c
     


### PR DESCRIPTION
Update genericParallelization.c so that the file mpi.h is only included when _IQTREE_MPI is defined