### PR TITLE
iqtree: close file descriptor.

### DIFF
--- a/tree/iqtree.cpp
+++ b/tree/iqtree.cpp
@@ -4253,6 +4253,7 @@ void IQTree::printPhylolibTree(const char* suffix) {
     FILE *phylolib_tree = fopen(phylolibTree, "w");
     fprintf(phylolib_tree, "%s", pllInst->tree_string);
     cout << "Tree optimized by Phylolib was written to " << phylolibTree << endl;
+    fclose(phylolib_tree);
 }
 
 void IQTree::printIntermediateTree(int brtype) {


### PR DESCRIPTION
The file descriptor was not closed which causes a resource leak when calling the method multiple times. Resource leaks can be problematic and even cause security issues.
Considering the use case here, it should not change anything, but it's probably better to close it anyway (or find a way to keep the same fd for all printing operations).