### PR TITLE
Add a CI job that builds with GCC/G++ 12 on Linux x86_64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc-version: [10, 12]
 
     steps:
     - name: Checkout
@@ -17,13 +21,16 @@ jobs:
         submodules: "recursive"
 
     - name: Install dependencies
-      run: sudo apt-get update -q -y && sudo apt-get install -q -y cmake libeigen3-dev libboost-dev
+      run: |
+        sudo apt-get update -q -y
+        sudo apt-get install -q -y gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version}} cmake libeigen3-dev libboost-dev
 
     - name: Build
       run: |
         mkdir build
         cd build
-        cmake ..
+        export CXXFLAGS="-std=c++14" # this is important to be able to build with g++ newer than v10
+        cmake .. -DCMAKE_C_COMPILER=$(which gcc-${{ matrix.gcc-version }}) -DCMAKE_CXX_COMPILER=$(which g++-${{ matrix.gcc-version }})
         make -j
         file iqtree2 | grep x86-64
 


### PR DESCRIPTION
Fixes #173

Adding `-std=c++14` to CXXFLAGS fixes the build with GCC 12