### PR TITLE
User warning when induced root not found in gCF

### DIFF
--- a/tree/discordance.cpp
+++ b/tree/discordance.cpp
@@ -725,8 +725,13 @@ void PhyloTree::computeGeneConcordance(MTreeSet &trees, map<string,string> &mean
         // create the map from taxa between 2 trees
         Split taxa_mask(leafNum);
         for (StrVector::iterator it = taxname.begin(); it != taxname.end(); it++) {
-            if (name_map.find(*it) == name_map.end())
+            if (name_map.find(*it) == name_map.end()) {
+                if (*it == "__root__") {
+                    cout << "WARNING : By default, trees without a multifurcation at the root are treated as rooted." << endl;
+                    cout << "          You may need to change your tree structure." << endl;
+                }
                 outError("Taxon not found in full tree: ", *it);
+            }
             taxa_mask.addTaxon(name_map[*it]);
         }
         // make the taxa ordering right before converting to split system

--- a/tree/mtree.cpp
+++ b/tree/mtree.cpp
@@ -2635,13 +2635,15 @@ void MTree::computeRFDist(istream &in, DoubleVector &dist, int assign_sup, bool 
 		// create the map from taxa between 2 trees
 		Split taxa_mask(leafNum);
 		for (StrVector::iterator it = taxname.begin(); it != taxname.end(); it++) {
-                    if (name_index.find(*it) == name_index.end()) {
+			if (name_index.find(*it) == name_index.end()) {
+                        	if (*it == "__root__") {
+					cout << "WARNING : By default, trees without a multifurcation at the root are treated as rooted." << endl;
+					cout << "          You may need to change your tree structure." << endl;
+				}
                         outError("Taxon not found in full tree: ", *it);
-                        if ( *it == "__root__" )
-                            outError( "By default, trees without a multifurcation at the root treated as rooted. You may need to change your tree structure." );
-                    }
-		    taxid = name_index[*it];
-		    taxa_mask.addTaxon(taxid);
+			} 
+			taxid = name_index[*it];
+			taxa_mask.addTaxon(taxid);
 		}
 		// make the taxa ordering right before converting to split system
 		taxname.clear();

--- a/tree/mtree.cpp
+++ b/tree/mtree.cpp
@@ -2635,10 +2635,13 @@ void MTree::computeRFDist(istream &in, DoubleVector &dist, int assign_sup, bool 
 		// create the map from taxa between 2 trees
 		Split taxa_mask(leafNum);
 		for (StrVector::iterator it = taxname.begin(); it != taxname.end(); it++) {
-            if (name_index.find(*it) == name_index.end())
-                outError("Taxon not found in full tree: ", *it);
-			taxid = name_index[*it];
-			taxa_mask.addTaxon(taxid);
+                    if (name_index.find(*it) == name_index.end()) {
+                        outError("Taxon not found in full tree: ", *it);
+                        if ( *it == "__root__" )
+                            outError( "By default, trees without a multifurcation at the root treated as rooted. You may need to change your tree structure." );
+                    }
+		    taxid = name_index[*it];
+		    taxa_mask.addTaxon(taxid);
 		}
 		// make the taxa ordering right before converting to split system
 		taxname.clear();


### PR DESCRIPTION
For users who run into the problem described in #248, emit a warning to clarify the likely cause of the error. This could also be regarded as a mitigation for #251. 

I've tried to respect the local whitespace usage. 