### PR TITLE
Support Exporting DNA/RNA Analysis to MrBayes Block Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tags
 test_scripts/iqtree_test_cmds.txt
 pllrepo/
 build/
+cmake-build-debug/
 /Default-clang
 .idea/
 .idea/codeStyleSettings.xml

--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -1156,6 +1156,12 @@ void printOutfilesInfo(Params &params, IQTree &tree) {
     if (params.optimize_linked_gtr) {
         cout << "  GTRPMIX nex file:              " << params.out_prefix << ".GTRPMIX.nex" << endl;
     }
+
+    if (params.mr_bayes_output) {
+        cout << endl << "MrBayes block written to:" << endl;
+        cout << "  Base template file:            " << params.out_prefix << ".mr_bayes_scheme.nex" << endl;
+        cout << "  Template file with parameters: " << params.out_prefix << ".mr_bayes_model.nex" << endl;
+    }
     cout << endl;
 
 }
@@ -3100,8 +3106,13 @@ void runTreeReconstruction(Params &params, IQTree* &iqtree) {
 
     }
     if (iqtree->isSuperTree()) {
-        ((PhyloSuperTree*) iqtree)->computeBranchLengths();
-        ((PhyloSuperTree*) iqtree)->printBestPartitionParams((string(params.out_prefix) + ".best_model.nex").c_str());
+        auto superTree = (PhyloSuperTree*) iqtree;
+        superTree->computeBranchLengths();
+        superTree->printBestPartitionParams((string(params.out_prefix) + ".best_model.nex").c_str());
+    }
+    if (params.mr_bayes_output) {
+        iqtree->printMrBayesBlock((string(params.out_prefix) + ".mr_bayes_scheme.nex").c_str(), false);
+        iqtree->printMrBayesBlock((string(params.out_prefix) + ".mr_bayes_model.nex").c_str(), true);
     }
 
     cout << "BEST SCORE FOUND : " << iqtree->getCurScore() << endl;

--- a/main/phylotesting.h
+++ b/main/phylotesting.h
@@ -390,5 +390,12 @@ string convertSeqTypeToSeqTypeName(SeqType seq_type);
 
 string detectSeqTypeName(string model_name);
 
+/**
+ * get string name from a SeqType object
+ * @param seq_type input sequence type
+ * @return name
+ */
+string getSeqTypeName(SeqType seq_type);
+
 
 #endif /* PHYLOTESTING_H_ */

--- a/model/modeldna.cpp
+++ b/model/modeldna.cpp
@@ -564,3 +564,7 @@ void ModelDNA::setVariables(double *variables) {
 //                              j++;
 //                      }
 }
+
+string ModelDNA::getModelDNACode() {
+    return param_spec;
+}

--- a/model/modeldna.h
+++ b/model/modeldna.h
@@ -114,6 +114,12 @@ public:
      */
     virtual void computeTipLikelihood(PML::StateType state, double *state_lk);
 
+    /**
+     * Get the Model DNA 'code', in form 'abcdef', used with ModelDNA model
+     * Returns empty string by default (this is not a dna specific model)
+     */
+    virtual string getModelDNACode();
+
 protected:
 
 	/**

--- a/model/modelsubst.h
+++ b/model/modelsubst.h
@@ -392,6 +392,12 @@ public:
     */
     virtual ModelSubst *getMutationModel() { return this; }
 
+    /**
+     * Get the Model DNA 'code', in form 'abcdef', used with ModelDNA model
+     * Returns empty string by default (this is not a dna specific model)
+     */
+     virtual string getModelDNACode() { return ""; }
+
 	/*****************************************************
 		Checkpointing facility
 	*****************************************************/

--- a/tree/phylosupertree.cpp
+++ b/tree/phylosupertree.cpp
@@ -1558,7 +1558,8 @@ void PhyloSuperTree::printCharsets(ofstream &out)
         if (!saln->partitions[part]->aln_file.empty()) out << saln->partitions[part]->aln_file << ": ";
         /*if (saln->partitions[part]->seq_type == SEQ_CODON)
             out << "CODON, ";*/
-        out << saln->partitions[part]->sequence_type << ", ";
+        if (!saln->partitions[part]->sequence_type.empty())
+            out << saln->partitions[part]->sequence_type << ", ";
         string pos = saln->partitions[part]->position_spec;
         replace(pos.begin(), pos.end(), ',' , ' ');
         out << pos << ";" << endl;
@@ -1577,6 +1578,7 @@ void PhyloSuperTree::printMrBayesBlock(const char *filename, bool inclParams)
     out << "  partition iqtree = " << listSize << ": ";
     for (int part = 0; part < listSize; part++) {
         string name = saln->partitions[part]->name;
+        replace(name.begin(), name.end(), '+', '_');
         out << name;
         if (part != listSize - 1) out << ", ";
         else out << ";" << endl;
@@ -1586,7 +1588,7 @@ void PhyloSuperTree::printMrBayesBlock(const char *filename, bool inclParams)
     out << "  set partition = iqtree;" << endl;
 
     // Set Outgroup (if available)
-    if (!rooted) out << "  outgroup " << root << ";" << endl << endl;
+    if (!rooted) out << "  outgroup " << root->name << ";" << endl << endl;
 
     // Partition-Specific Model Information
     for (int part = 0; part < listSize; part++) {

--- a/tree/phylosupertree.h
+++ b/tree/phylosupertree.h
@@ -482,17 +482,18 @@ public:
       */
     virtual void printMrBayesBlock(const char *filename, bool inclParams);
 
+    /**
+     * Prints the replacement prior settings for +R or +R+I.
+     * @param rate the heterogeneity rate
+     * @param charset the (original) charset of the current partition. An empty string if not a partitioned tree
+     * @param out the ofstream to print to
+     */
+    virtual void printMrBayesFreeRateReplacement(RateHeterogeneity* rate, string &charset, ofstream &out);
+
     /** True when mixed codon with other data type */
     bool rescale_codon_brlen;
 
     int totalNNIs, evalNNIs;
-
-private:
-    /**
-       print charset information of the best model into an ofstream
-       @param out output stream
-     */
-     void printCharsets(ofstream &out);
 };
 
 #endif

--- a/tree/phylosupertree.h
+++ b/tree/phylosupertree.h
@@ -475,12 +475,24 @@ public:
      */
     void printBestPartitionParams(const char *filename);
 
-    
+    /**
+        print mr bayes block with partition information and best model parameters
+        @param filename output file name
+        @param inclParams whether to include iqtree params
+      */
+    virtual void printMrBayesBlock(const char *filename, bool inclParams);
+
     /** True when mixed codon with other data type */
     bool rescale_codon_brlen;
-    
+
     int totalNNIs, evalNNIs;
 
+private:
+    /**
+       print charset information of the best model into an ofstream
+       @param out output stream
+     */
+     void printCharsets(ofstream &out);
 };
 
 #endif

--- a/tree/phylotree.h
+++ b/tree/phylotree.h
@@ -2265,11 +2265,19 @@ public:
     const string& getDistanceFileWritten() const;
 
     /**
-        print mr bayes block with partition information and best model parameters
+        print MrBayes block with partition information, and best model parameters (if inclParams is true)
         @param filename output file name
         @param inclParams whether to include iqtree params
       */
     virtual void printMrBayesBlock(const char *filename, bool inclParams);
+
+    /**
+     * Prints the replacement prior settings for +R or +R+I.
+     * @param rate the heterogeneity rate
+     * @param charset the (original) charset of the current partition. An empty string if not a partitioned tree
+     * @param out the ofstream to print to
+     */
+    virtual void printMrBayesFreeRateReplacement(RateHeterogeneity* rate, string &charset, ofstream &out);
 
     
 protected:
@@ -2516,25 +2524,24 @@ protected:
     void hideProgress();
     void showProgress();
     void doneProgress();
-
-    /**
-     * print MrBayes formatted text, of model information (and parameters), to an ofstream.
-     * @param tree tree to print info from
-     * @param out stream to print to
-     * @param partition the partition to 'apply' to (all to apply to all partitions)
-     * @param inclParams whether to include the parameters of the model
-     */
-    void printMrBayesModelText(ofstream& out, string partition, bool inclParams);
-
-    /**
-     * Start a MrBayes Block, as well as printing a warning.
-     * @param filename output file name
-     * @return ofstream for other functions to print to
-     */
-    ofstream startMrBayesBlock(const char *filename);
-
-private:
-    void printMrBayesModelTextDNA(ofstream &out, string partition, bool inclParams);
 };
+
+/**
+ * print MrBayes formatted text, of model information (and parameters), to an ofstream.
+ * @param originalTree the original tree, of which is called to retrieve values in checkpoint file (to allow for overriding)
+ * @param tree tree to print info from
+ * @param out stream to print to
+ * @param partition the partition to 'apply' to (all to apply to all partitions)
+ * @param charset the (original) charset of the current partition. Used to retrieve values in checkpoint file. Input an empty string if this is not a partitioned tree.
+ * @param inclParams whether to include the parameters of the model
+ */
+void printMrBayesModelText(PhyloTree* originalTree, PhyloTree* tree, ofstream& out, string partition, string charset, bool inclParams);
+
+/**
+ * Start a MrBayes Block, as well as printing a warning.
+ * @param filename output file name
+ * @return ofstream for other functions to print to
+ */
+ofstream startMrBayesBlock(const char *filename);
 
 #endif

--- a/tree/phylotree.h
+++ b/tree/phylotree.h
@@ -2264,6 +2264,13 @@ public:
      */
     const string& getDistanceFileWritten() const;
 
+    /**
+        print mr bayes block with partition information and best model parameters
+        @param filename output file name
+        @param inclParams whether to include iqtree params
+      */
+    virtual void printMrBayesBlock(const char *filename, bool inclParams);
+
     
 protected:
 
@@ -2509,6 +2516,25 @@ protected:
     void hideProgress();
     void showProgress();
     void doneProgress();
+
+    /**
+     * print MrBayes formatted text, of model information (and parameters), to an ofstream.
+     * @param tree tree to print info from
+     * @param out stream to print to
+     * @param partition the partition to 'apply' to (all to apply to all partitions)
+     * @param inclParams whether to include the parameters of the model
+     */
+    void printMrBayesModelText(ofstream& out, string partition, bool inclParams);
+
+    /**
+     * Start a MrBayes Block, as well as printing a warning.
+     * @param filename output file name
+     * @return ofstream for other functions to print to
+     */
+    ofstream startMrBayesBlock(const char *filename);
+
+private:
+    void printMrBayesModelTextDNA(ofstream &out, string partition, bool inclParams);
 };
 
 #endif

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -6315,7 +6315,8 @@ void usage_iqtree(char* argv[], bool full_command) {
     //			<< "  -stats <outfile>     Output some statistics about branch lengths" << endl
     //			<< "  -comp <treefile>     Compare tree with each in the input trees" << endl;
         << "  -mrbayes             Outputs a Mr Bayes block file, to use as a template for future analysis" << endl
-        << "                       Will not output if incompatible data types are used (anything apart from DNA, Codon and Protein)" << endl
+        << "                       Will not output if incompatible data types are used" << endl
+        << "                       (MrBayes only supports DNA, Codon, Protein, Binary and Morphological data)" << endl
         << endl;
 
     if (full_command) {

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -1524,6 +1524,7 @@ void parseArg(int argc, char *argv[], Params &params) {
     params.include_pre_mutations = false;
     params.mutation_file = "";
     params.site_starting_index = 0;
+    params.mr_bayes_output = false;
     
     // store original params
     for (cnt = 1; cnt < argc; cnt++) {
@@ -5662,7 +5663,10 @@ void parseArg(int argc, char *argv[], Params &params) {
                 params.make_consistent = true;
                 continue;
             }
-            
+            if (strcmp(argv[cnt], "-mrbayes") == 0) {
+                params.mr_bayes_output = true;
+                continue;
+            }
             if (argv[cnt][0] == '-') {
                 string err = "Invalid \"";
                 err += argv[cnt];
@@ -5800,6 +5804,10 @@ void parseArg(int argc, char *argv[], Params &params) {
     if (params.model_name.find("LINK") != string::npos || params.model_name.find("MERGE") != string::npos)
         if (params.partition_merge == MERGE_NONE)
             params.partition_merge = MERGE_RCLUSTERF;
+
+    // Set MrBayes Block Output if -mset mrbayes
+    if (params.model_set == "mrbayes")
+        params.mr_bayes_output = true;
     
     if (params.alisim_active && !params.aln_file && !params.user_file && !params.partition_file && params.tree_gen == NONE)
         outError("A tree filepath is a mandatory input to execute AliSim when neither Inference mode nor Random mode (generating a random tree) is inactive. Use -t <TREE_FILEPATH> ; or Activate the inference mode by -s <ALIGNMENT_FILE> ; or Activate Random mode by -t RANDOM{<MODEL>,<NUM_TAXA>} where <MODEL> is yh, u, cat, bal, bd{<birth_rate>,<death_rate>} stands for Yule-Harding, Uniform, Caterpillar, Balanced, Birth-Death model respectively.");
@@ -6014,7 +6022,7 @@ void usage_iqtree(char* argv[], bool full_command) {
 //            << "  -pll                 Use phylogenetic likelihood library (PLL) (default: off)" << endl
     << "  --ninit NUM          Number of initial parsimony trees (default: 100)" << endl
     << "  --ntop NUM           Number of top initial trees (default: 20)" << endl
-    << "  --nbest NUM          Number of best trees retained during search (defaut: 5)" << endl
+    << "  --nbest NUM          Number of best trees retained during search (default: 5)" << endl
     << "  -n NUM               Fix number of iterations to stop (default: OFF)" << endl
     << "  --nstop NUM          Number of unsuccessful iterations to stop (default: 100)" << endl
     << "  --perturb NUM        Perturbation strength for randomized NNI (default: 0.5)" << endl
@@ -6071,6 +6079,8 @@ void usage_iqtree(char* argv[], bool full_command) {
     << "  -m ...+LMSS          Additionally test strand-symmetric models" << endl
     << "  --mset STRING        Restrict search to models supported by other programs" << endl
     << "                       (raxml, phyml, mrbayes, beast1 or beast2)" << endl
+    << "                       If 'mrbayes' is selected, will auto update a MrBayes" << endl
+    << "                       Block File if Data Type is supported." << endl
     << "  --mset STR,...       Comma-separated model list (e.g. -mset WAG,LG,JTT)" << endl
     << "  --msub STRING        Amino-acid model source" << endl
     << "                       (nuclear, mitochondrial, chloroplast or viral)" << endl
@@ -6304,8 +6314,8 @@ void usage_iqtree(char* argv[], bool full_command) {
     //			<< "  -d <outfile>         Calculate the distance matrix inferred from tree" << endl
     //			<< "  -stats <outfile>     Output some statistics about branch lengths" << endl
     //			<< "  -comp <treefile>     Compare tree with each in the input trees" << endl;
-
-
+        << "  -mrbayes             Outputs a Mr Bayes block file, to use as a template for future analysis" << endl
+        << "                       Will not output if incompatible data types are used (anything apart from DNA, Codon and Protein)" << endl
         << endl;
 
     if (full_command) {

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -6079,7 +6079,7 @@ void usage_iqtree(char* argv[], bool full_command) {
     << "  -m ...+LMSS          Additionally test strand-symmetric models" << endl
     << "  --mset STRING        Restrict search to models supported by other programs" << endl
     << "                       (raxml, phyml, mrbayes, beast1 or beast2)" << endl
-    << "                       If 'mrbayes' is selected, will auto update a MrBayes" << endl
+    << "                       If 'mrbayes' is selected, will output a MrBayes" << endl
     << "                       Block File if Data Type is supported." << endl
     << "  --mset STR,...       Comma-separated model list (e.g. -mset WAG,LG,JTT)" << endl
     << "  --msub STRING        Amino-acid model source" << endl

--- a/utils/tools.h
+++ b/utils/tools.h
@@ -2781,6 +2781,11 @@ public:
     *  site starting index (for predefined mutations in AliSim)
     */
     int site_starting_index;
+
+    /**
+    * Whether to output a MrBayes Block File
+    */
+    bool mr_bayes_output;
 };
 
 /**
@@ -3727,6 +3732,5 @@ double frob_norm (double m[], int n, double scale=1.0);
     concatenate the output file name with corresponding extension (for AliSim)
 */
 string getOutputNameWithExt(const InputType& format, const string& output_filepath);
-
 
 #endif


### PR DESCRIPTION
This PR provides the base MrBayes integration, completing https://github.com/iqtree/iqtree2/issues/195 for DNA/RNA analysis.

The code is not fully tested, and there may be some edge cases to be solved further, such as Mixture Models and Non-Time Reversible Models.

Current cases which have been tested:
- Non-Partitioned Output + Importing into MrBayes
- Partitioned Output + Importing into MrBayes
- Merged Partitioned Output + Importing into MrBayes
- Mapping of `+R` models
- Mapping of custom defined models (e.g. `010010` to `nst=2`)

Base Logic:
- MrBayes files will be outputted when the user provides the `-mset mrbayes`, or adds the `-mrbayes` flag
- Two MrBayes files will be exported: one with parameters optimized from IQTree (`.mr_bayes_model.nex`), and one without (`.mr_bayes_scheme.nex`)
- MrBayes files will be outputted on partitioned and non-partitioned runs

Support is planned for Protein, Codon, Binary and Morphological Data.