### PR TITLE
Support Exporting Codon Analysis to MrBayes Block Files

### DIFF
--- a/alignment/alignment.cpp
+++ b/alignment/alignment.cpp
@@ -1641,13 +1641,13 @@ void Alignment::initCodon(char *gene_code_id) {
 		} catch (string &str) {
 			outError("Wrong genetic code ", gene_code_id);
 		}
-        auto codeMap = getGeneticCodeMap();
-        auto found = codeMap.left.find(transl_table);
+		auto codeMap = getGeneticCodeMap();
+		auto found = codeMap.left.find(transl_table);
 		if (found == codeMap.left.end()) {
 			outError("Wrong genetic code ", gene_code_id);
-            return;
+			return;
 		}
-        genetic_code = found->second;
+		genetic_code = found->second;
 	} else {
 		genetic_code = genetic_code1;
 	}

--- a/alignment/alignment.h
+++ b/alignment/alignment.h
@@ -1010,6 +1010,12 @@ public:
      */
     void extractMapleFile(const std::string& aln_name, const InputType& format);
 
+    /**
+     * Get the numerical id of the genetic code
+     * @return id the genetic code id, or 0 if not a codon type
+     */
+    int getGeneticCodeId();
+
 protected:
 
 

--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -2626,7 +2626,7 @@ void printMrBayesBlockFile(const char* filename, IQTree* &iqtree, bool inclParam
         if (!iqtree->rooted) out << "  outgroup " << iqtree->root->name << ";" << endl << endl;
 
         out << "  [Using Model '" << iqtree->getModelName() << "']" << endl;
-        iqtree->getModel()->printMrBayesModelText(iqtree->getRate(), out, "all", "", false, inclParams);
+        iqtree->getModel()->printMrBayesModelText(out, "all", "", false, inclParams);
 
         out << endl << "end;" << endl;
         out.close();
@@ -2670,7 +2670,7 @@ void printMrBayesBlockFile(const char* filename, IQTree* &iqtree, bool inclParam
 
         // MrBayes Partitions are 1-indexed
         out << "  [Partition No. " << convertIntToString(part + 1) << ", Using Model '" << currentTree->getModelName() << "']" << endl;
-        currentTree->getModel()->printMrBayesModelText(currentTree->getRate(), out,
+        currentTree->getModel()->printMrBayesModelText(out,
                 convertIntToString(part + 1), saln->partitions[part]->name, true, inclParams);
         out << endl;
     }

--- a/main/phyloanalysis.cpp
+++ b/main/phyloanalysis.cpp
@@ -2608,11 +2608,21 @@ void printMrBayesBlockFile(const char* filename, IQTree* &iqtree, bool inclParam
         out.exceptions(ios::failbit | ios::badbit);
         out.open(filename);
 
+        string provide = "basic models";
+        if (inclParams) provide = "optimized values";
+        else if (iqtree->isSuperTree()) provide = "basic partition structure and models";
+
         // Write Warning
         out << "#nexus" << endl << endl
-            <<"[This MrBayes Block Declaration provides the retrieved values from the IQTree Run.]" << endl
-            << "[Note that MrBayes does not support a large collection of models, so defaults of 'nst=6' for DNA and 'wag' for Protein will be used if a model that does not exist in MrBayes is selected.]" << endl
-            << "[Furthermore, the Model Parameter '+R' will be replaced by '+G'.]" << endl
+            <<"[This MrBayes Block Declaration provides the " << provide << " from the IQTree Run.]" << endl
+            << "[Note that MrBayes does not support a large collection of models, so defaults of 'nst=6' for DNA and 'wag' for Protein will be used if a model that does not exist in MrBayes is used.]" << endl;
+
+        if (inclParams)
+            out << "[However, for those cases, there will still be a rate matrix provided.]" << endl
+                << "[For DNA, this will still mean the rates may vary outside the restrictions of the model.]" << endl
+                << "[For Protein, this is essentially a perfect replacement.]" << endl;
+
+        out << "[Furthermore, the Model Parameter '+R' will be replaced by '+G'.]" << endl
             << "[This should be used as a Template Only.]" << endl << endl;
 
         // Begin File, Print Charsets

--- a/model/modelbin.cpp
+++ b/model/modelbin.cpp
@@ -77,7 +77,9 @@ string ModelBIN::getNameParams(bool show_fixed_params) {
     return retname.str();
 }
 
-void ModelBIN::printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
+void ModelBIN::printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
+    RateHeterogeneity* rate = phylo_tree->getRate();
+
     // MrBayes does not support Invariable Modifier for Binary data
     if (rate->isFreeRate() || rate->getPInvar() > 0.0) {
         warnLogStream("MrBayes does not support Invariable Sites with Binary Data! +I has been ignored!", out);

--- a/model/modelbin.h
+++ b/model/modelbin.h
@@ -65,7 +65,7 @@ public:
      * @param isSuperTree whether the tree is a super tree. Useful for retrieving information from the checkpoint file, which has different locations for PhyloTree and PhyloSuperTree
      * @param inclParams whether to include IQTree optimized parameters for the model
      */
-    virtual void printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
+    virtual void printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
 
 };
 

--- a/model/modelcodon.cpp
+++ b/model/modelcodon.cpp
@@ -1142,6 +1142,72 @@ double ModelCodon::optimizeParameters(double gradient_epsilon) {
 	return score;
 }
 
+void ModelCodon::printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
+    // NST should be 1 if fix_kappa is true (no ts/tv ratio), else it should be 2
+    int nst = fix_kappa ? 1 : 2;
+    int code = phylo_tree->aln->getGeneticCodeId();
+    string mrBayesCode = getMrBayesGeneticCode(code);
+    RateHeterogeneity* rate = phylo_tree->getRate();
+
+    if (rate->isFreeRate() || rate->getGammaShape() > 0.0 || rate->getPInvar() > 0.0) {
+        warnLogStream("MrBayes Codon Models do not support any Heterogenity Rate Modifiers! (+I, +G, +R) They have been ignored!", out);
+    }
+
+    if (mrBayesCode.empty()) {
+        warnLogStream("MrBayes Does Not Support Codon Code " + convertIntToString(code) + "! Defaulting to Universal (Code 1).", out);
+        mrBayesCode = "universal";
+    }
+
+    if (freq_type == FREQ_USER_DEFINED || name.find('_') != string::npos) { // If this model is a Empirical / Semi-Empirical Model
+        warnLogStream("MrBayes does not support Empirical Codon Models. State Frequency will still be set, but no rate matrix will be set.", out);
+    }
+
+    out << "  lset applyto=(" << partition << ") omegavar=equal nst=" << nst << " code=" << mrBayesCode << ";" << endl;
+
+    if (!inclParams) return;
+
+    out << "  prset applyto=(" << partition << ") statefreqpr=dirichlet(";
+
+    // State Frequency Prior
+    bool isFirst = true;
+    for (int i = 0; i < num_states; i++) {
+        if (phylo_tree->aln->isStopCodon(i)) continue;
+
+        if (!isFirst) out << ", ";
+        else isFirst = false;
+
+        out << state_freq[i];
+    }
+
+    out << ")";
+
+    /*
+     * TS/TV Ratio (Kappa)
+     * Ratio Should be:
+     * `beta(kappa, 1)` when `codon_kappa_style` is `CK_ONE_KAPPA` (kappa here represents the ts/tv rate ratio)
+     * `beta(kappa, 1)` when `codon_kappa_style` is `CK_ONE_KAPPA_TS` (kappa here represents the transition rate)
+     * `beta(1, kappa)` when `codon_kappa_style` is `CK_ONE_KAPPA_TV` (kappa here represents the transversion rate)
+     * `beta(kappa, kappa2)` when `codon_kappa_style` is `CK_TWO_KAPPA` (kappa here represents the transition rate, and kappa2 represents the transversion rate)
+     */
+    if (!fix_kappa) {
+        double v1 = codon_kappa_style == CK_ONE_KAPPA_TV ? 1 : kappa;
+        double v2 = 1;
+        if (codon_kappa_style == CK_ONE_KAPPA_TV)
+            v2 = kappa;
+        else if (codon_kappa_style == CK_TWO_KAPPA)
+            v2 = kappa2;
+
+        out << " tratiopr=beta(" << v1 << ", " << v2 << ")";
+    }
+
+    // DN/DS Ratio (Omega)
+    // Ratio is set to `dirichlet(omega, 1)`
+    if (!fix_omega) {
+        out << " omegapr=dirichlet(" << omega << ", 1)";
+    }
+
+    out << ";" << endl;
+}
 
 void ModelCodon::writeInfo(ostream &out) {
     if (name.find('_') == string::npos)

--- a/model/modelcodon.cpp
+++ b/model/modelcodon.cpp
@@ -1162,7 +1162,7 @@ void ModelCodon::printMrBayesModelText(ofstream& out, string partition, string c
         warnLogStream("MrBayes does not support Empirical Codon Models. State Frequency will still be set, but no rate matrix will be set.", out);
     }
 
-    out << "  lset applyto=(" << partition << ") omegavar=equal nst=" << nst << " code=" << mrBayesCode << ";" << endl;
+    out << "  lset applyto=(" << partition << ") nucmodel=codon omegavar=equal nst=" << nst << " code=" << mrBayesCode << ";" << endl;
 
     if (!inclParams) return;
 

--- a/model/modelcodon.cpp
+++ b/model/modelcodon.cpp
@@ -1158,8 +1158,8 @@ void ModelCodon::printMrBayesModelText(ofstream& out, string partition, string c
         mrBayesCode = "universal";
     }
 
-    if (freq_type == FREQ_USER_DEFINED || name.find('_') != string::npos) { // If this model is a Empirical / Semi-Empirical Model
-        warnLogStream("MrBayes does not support Empirical Codon Models. State Frequency will still be set, but no rate matrix will be set.", out);
+    if (num_params == 0 || name.find('_') != string::npos) { // If this model is a Empirical / Semi-Empirical Model
+        warnLogStream("MrBayes does not support Empirical or Semi-Empirical Codon Models. State Frequency will still be set, but no rate matrix will be set.", out);
     }
 
     out << "  lset applyto=(" << partition << ") nucmodel=codon omegavar=equal nst=" << nst << " code=" << mrBayesCode << ";" << endl;

--- a/model/modelcodon.h
+++ b/model/modelcodon.h
@@ -210,6 +210,17 @@ protected:
 	*/
 	virtual bool getVariables(double *variables);
 
+    /**
+     * Print the model information in a format that can be accepted by MrBayes, using lset and prset.<br>
+     * By default, it simply prints a warning to the log and to the stream, stating that this model is not supported by MrBayes.
+     * @param out the ofstream to print the result to
+     * @param partition the partition to apply lset and prset to
+     * @param charset the current partition's charset. Useful for getting information from the checkpoint file
+     * @param isSuperTree whether the tree is a super tree. Useful for retrieving information from the checkpoint file, which has different locations for PhyloTree and PhyloSuperTree
+     * @param inclParams whether to include IQTree optimized parameters for the model
+     */
+    virtual void printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
+
 };
 
 #endif /* MODELCODON_H_ */

--- a/model/modeldna.cpp
+++ b/model/modeldna.cpp
@@ -565,9 +565,10 @@ void ModelDNA::setVariables(double *variables) {
 //                      }
 }
 
-void ModelDNA::printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
+void ModelDNA::printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
     bool equalFreq = freq_type == FREQ_EQUAL;
     short nst = 6;
+    RateHeterogeneity* rate = phylo_tree->getRate();
 
     // Find NST value (1 for JC/JC69/F81, 2 for K80/K2P/HKY/HKY85, 6 for SYM/GTR)
     // NST is set to 6 by default (above), so check for JC/JC69/F81 and K80/K2P/HKY/HKY85

--- a/model/modeldna.h
+++ b/model/modeldna.h
@@ -117,14 +117,13 @@ public:
     /**
      * Print the model information in a format that can be accepted by MrBayes, using lset and prset.<br>
      * By default, it simply prints a warning to the log and to the stream, stating that this model is not supported by MrBayes.
-     * @param rate the rate information
      * @param out the ofstream to print the result to
      * @param partition the partition to apply lset and prset to
      * @param charset the current partition's charset. Useful for getting information from the checkpoint file
      * @param isSuperTree whether the tree is a super tree. Useful for retrieving information from the checkpoint file, which has different locations for PhyloTree and PhyloSuperTree
      * @param inclParams whether to include IQTree optimized parameters for the model
      */
-    virtual void printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
+    virtual void printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
 
 protected:
 

--- a/model/modelmorphology.cpp
+++ b/model/modelmorphology.cpp
@@ -151,10 +151,12 @@ void ModelMorphology::writeInfo(ostream &out) {
     }
 }
 
-void ModelMorphology::printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
+void ModelMorphology::printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
     warnLogStream("MrBayes only supports Morphological Data with states from {0-9}!", out);
     warnLogStream("Morphological Data with states {A-Z} may cause errors!", out);
     warnLogStream("Use Morphological Models in MrBayes with Caution!", out);
+
+    RateHeterogeneity* rate = phylo_tree->getRate();
 
     // MrBayes does not support Invariable Modifier for Morph data
     if (rate->isFreeRate() || rate->getPInvar() > 0.0) {

--- a/model/modelmorphology.h
+++ b/model/modelmorphology.h
@@ -82,14 +82,13 @@ public:
     /**
      * Print the model information in a format that can be accepted by MrBayes, using lset and prset.<br>
      * By default, it simply prints a warning to the log and to the stream, stating that this model is not supported by MrBayes.
-     * @param rate the rate information
      * @param out the ofstream to print the result to
      * @param partition the partition to apply lset and prset to
      * @param charset the current partition's charset. Useful for getting information from the checkpoint file
      * @param isSuperTree whether the tree is a super tree. Useful for retrieving information from the checkpoint file, which has different locations for PhyloTree and PhyloSuperTree
      * @param inclParams whether to include IQTree optimized parameters for the model
      */
-    virtual void printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
+    virtual void printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
 };
 
 #endif /* MODELMORPHOLOGY_H_ */

--- a/model/modelprotein.cpp
+++ b/model/modelprotein.cpp
@@ -1162,9 +1162,11 @@ void ModelProtein::computeTipLikelihood(PML::StateType state, double *state_lk) 
     state_lk[ambi_aa[cstate*2+1]] = 1.0;
 }
 
-void ModelProtein::printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
+void ModelProtein::printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
     // Lset Parameters
     out << "  lset applyto=(" << partition << ") nucmodel=protein rates=";
+
+    RateHeterogeneity* rate = phylo_tree->getRate();
 
     // RHAS Specification
     // Free Rate should be substituted by +G+I

--- a/model/modelprotein.h
+++ b/model/modelprotein.h
@@ -82,14 +82,13 @@ public:
     /**
      * Print the model information in a format that can be accepted by MrBayes, using lset and prset.<br>
      * By default, it simply prints a warning to the log and to the stream, stating that this model is not supported by MrBayes.
-     * @param rate the rate information
      * @param out the ofstream to print the result to
      * @param partition the partition to apply lset and prset to
      * @param charset the current partition's charset. Useful for getting information from the checkpoint file
      * @param isSuperTree whether the tree is a super tree. Useful for retrieving information from the checkpoint file, which has different locations for PhyloTree and PhyloSuperTree
      * @param inclParams whether to include IQTree optimized parameters for the model
      */
-    virtual void printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
+    virtual void printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
 
 private:
     ModelsBlock *models_block;

--- a/model/modelsubst.cpp
+++ b/model/modelsubst.cpp
@@ -246,7 +246,7 @@ void ModelSubst::printMrBayesFreeRateReplacement(bool isSuperTree, string &chars
         out << " pinvarpr=fixed(" << minValueCheckMrBayes(p_invar) << ")";
 }
 
-void ModelSubst::printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
+void ModelSubst::printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams) {
     out << "  [MrBayes Block Output is not supported by this model!]" << endl;
     outWarning("MrBayes Block Output is not supported by this model of name '" + name + "'!");
 }

--- a/model/modelsubst.h
+++ b/model/modelsubst.h
@@ -405,18 +405,6 @@ public:
     /**
      * Print the model information in a format that can be accepted by MrBayes, using lset and prset.<br>
      * By default, it simply prints a warning to the log and to the stream, stating that this model is not supported by MrBayes.
-     * @param rate the rate information
-     * @param out the ofstream to print the result to
-     * @param partition the partition to apply lset and prset to
-     * @param charset the current partition's charset. Useful for getting information from the checkpoint file
-     * @param isSuperTree whether the tree is a super tree. Useful for retrieving information from the checkpoint file, which has different locations for PhyloTree and PhyloSuperTree
-     * @param inclParams whether to include IQTree optimized parameters for the model
-     */
-    virtual void printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
-
-    /**
-     * Print the model information in a format that can be accepted by MrBayes, using lset and prset.<br>
-     * By default, it simply prints a warning to the log and to the stream, stating that this model is not supported by MrBayes.
      * @param out the ofstream to print the result to
      * @param partition the partition to apply lset and prset to
      * @param charset the current partition's charset. Useful for getting information from the checkpoint file

--- a/model/modelsubst.h
+++ b/model/modelsubst.h
@@ -414,6 +414,17 @@ public:
      */
     virtual void printMrBayesModelText(RateHeterogeneity* rate, ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
 
+    /**
+     * Print the model information in a format that can be accepted by MrBayes, using lset and prset.<br>
+     * By default, it simply prints a warning to the log and to the stream, stating that this model is not supported by MrBayes.
+     * @param out the ofstream to print the result to
+     * @param partition the partition to apply lset and prset to
+     * @param charset the current partition's charset. Useful for getting information from the checkpoint file
+     * @param isSuperTree whether the tree is a super tree. Useful for retrieving information from the checkpoint file, which has different locations for PhyloTree and PhyloSuperTree
+     * @param inclParams whether to include IQTree optimized parameters for the model
+     */
+    virtual void printMrBayesModelText(ofstream& out, string partition, string charset, bool isSuperTree, bool inclParams);
+
 	/*****************************************************
 		Checkpointing facility
 	*****************************************************/

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -7925,22 +7925,30 @@ double minValueCheckMrBayes(double origValue) {
      return origValue;
 }
 
-// Cached Map
-unordered_map<string, string> iqTreeToMrBayesAAModels;
+const unordered_map<string, string> iqTreeToMrBayesAAModels = {
+        {"Poisson", "poisson"},
+        {"JTT", "jones"},
+        {"Dayhoff", "dayhoff"},
+        {"mtREV", "mtrev"},
+        {"mtMAM", "mtmam"},
+        {"WAG", "wag"},
+        {"rtREV", "rtrev"},
+        {"cpREV", "cprev"},
+        {"VT", "vt"},
+        {"Blosum62", "blosum"},
+        {"LG", "lg"},
+};
+
+// Anything outside of index 10 (Code No. 11) is invalid, leave that as empty string
+const string indexedMrBayesGeneticCodes[25] = {"universal", "vertmt", "yeast", "mycoplasma", "invermt",
+                                               "ciliate", "", "", "echinoderm", "euplotid", "universal"};
 
 unordered_map<string, string> getIqTreeToMrBayesAAModels() {
-    if (!iqTreeToMrBayesAAModels.empty()) return iqTreeToMrBayesAAModels;
-
-    iqTreeToMrBayesAAModels["Poisson"] = "poisson";
-    iqTreeToMrBayesAAModels["JTT"] = "jones";
-    iqTreeToMrBayesAAModels["Dayhoff"] = "dayhoff";
-    iqTreeToMrBayesAAModels["mtREV"] = "mtrev";
-    iqTreeToMrBayesAAModels["mtMAM"] = "mtmam";
-    iqTreeToMrBayesAAModels["WAG"] = "wag";
-    iqTreeToMrBayesAAModels["rtREV"] = "rtrev";
-    iqTreeToMrBayesAAModels["cpREV"] = "cprev";
-    iqTreeToMrBayesAAModels["VT"] = "vt";
-    iqTreeToMrBayesAAModels["Blosum62"] = "blosum";
-    iqTreeToMrBayesAAModels["LG"] = "lg";
     return iqTreeToMrBayesAAModels;
+}
+
+string getMrBayesGeneticCode(int geneticCodeId) {
+    if (geneticCodeId == 0) return "";
+
+    return indexedMrBayesGeneticCodes[geneticCodeId - 1];
 }

--- a/utils/tools.cpp
+++ b/utils/tools.cpp
@@ -7912,9 +7912,9 @@ string getOutputNameWithExt(const InputType& format, const string& output_filepa
     }
 }
 
-void warnLogStream(string warn, ofstream &out) {
+void warnLogStream(string warn, ofstream &out, string indentation) {
     outWarning(warn);
-    out << "[" << warn << "]" << endl;
+    out << indentation << "[" << warn << "]" << endl;
 }
 
 double minValueCheckMrBayes(double origValue) {

--- a/utils/tools.h
+++ b/utils/tools.h
@@ -3750,4 +3750,10 @@ double minValueCheckMrBayes(double origValue);
  */
 unordered_map<string, string> getIqTreeToMrBayesAAModels();
 
+/**
+ * get the MrBayes equivalent of a genetic code, given the id of the code. Returns and empty string if that code
+ * is not supported in MrBayes.
+ */
+string getMrBayesGeneticCode(int geneticCodeId);
+
 #endif

--- a/utils/tools.h
+++ b/utils/tools.h
@@ -3735,8 +3735,11 @@ string getOutputNameWithExt(const InputType& format, const string& output_filepa
 
 /**
  * Prints a warning message to the log and to the ofstream, in a NEXUS format.
+ * @param warn the message to print
+ * @param out the ofstream to print to
+ * @param indentation optional indentation included only in ofstream. defaults to two spaces
  */
-void warnLogStream(string warn, ofstream &out);
+void warnLogStream(string warn, ofstream &out, string indentation = "  ");
 
 /**
  * ensures a number, to be inputted into MrBayes, is larger than the minimum value for MrBayes (0.01)


### PR DESCRIPTION
## Introduction
This PR implements exporting the final sequence type to MrBayes: Codon Models. This therefore finishes the implementation of https://github.com/iqtree/iqtree2/issues/195, excluding any changes required further from suggestions and bug fixes after testing has been conducted.

## Codon Models in MrBayes: Introduction
The basic structure for codon models in MrBayes is quite similar to *mechanistic* codon models in IQTree, following the same formulation of the model by [Goldman & Yang 1994](http://mbe.oxfordjournals.org/content/11/5/725.abstract) and [Muse & Gaut 1994](http://mbe.oxfordjournals.org/content/11/5/715.abstract). However, the settings for MrBayes are under different names, and most inputs cannot be ported directly.

Instead of using named models, such as `MG` or `GY`, MrBayes uses five main parameters:
- Nucleotide Substitution Model (From `JC`, `HKY` and `GTR`), set through `lset nst` (`nst = 1` for `JC`, `nst = 2` for `HKY`, `nst = 6` for `GTR`)
- The Transition/Transversion (ts/tv) Rate Ratio (set through `prset tratiopr`)
- The Non-Synonymous/Synonymous (dn/ds) Rate Ratio (set through `prset omegapr`)
- The State Frequencies of each *non-stop* codon (set through `prset statefreqpr`)
- The Omega Variation Type and Corresponding Parameters (set through `lset omegavar`)

(Source: [MrBayes Manual (Chapter 6.1.3 & Appendix A)](https://github.com/NBISweden/MrBayes/blob/develop/doc/manual/Manual_MrBayes_v3.2.pdf), MrBayes `help lset` and `help prset` commands, [IQTree Documentation on Substitution Models (Section on Codon Models)](http://www.iqtree.org/doc/Substitution-Models#codon-models))

## Mechanistic Model Output
### Nucleotide Substitution Model
For retrieving the nucleotide substitution model that should be used as input into MrBayes, the implemented code does the following:
- If `fix_kappa` is true, then the model will be set to `nst = 1` (JC)
- If `fix_kappa` is false, then the model will be set to `nst = 2` (HKY)

This implementation means that GTR is not used, appropriate considering the inputs for Mechanistic Codon Models in IQTree (ds/dt ratio + ts/tv ratio).

Note that `fix_kappa` is only set to true under the Codon Models `MGK` and `GY0K` (which are the only models without a `ts/tv` input ratio). This can be shown through the [`initCodon` function](https://github.com/iqtree/iqtree2/blob/master/model/modelcodon.cpp#L323-L366), which only calls `initMG94` or `initGY94` with `fix_kappa` as true for those two models. That input is then read into the `fix_kappa` field [here for MG Models](https://github.com/iqtree/iqtree2/blob/master/model/modelcodon.cpp#L515) and [here for GY Models](https://github.com/iqtree/iqtree2/blob/master/model/modelcodon.cpp#L551).

### TS/TV Rate Ratio
In IQTree, `ModelCodon` stores two values for the `kappa`, or the ts/tv rate ratio:
- `kappa`, which represents the ts/tv rate ratio for 'normal' MG/GY models
- `kappa2`, which represents the ts/tv rate ratio for '2-Kappa' MG/GY modles

However, for the `tratiopr` input in MrBayes, there are two types of input available:
- `fixed`, which takes one input (ts/tv rate ratio), and fixes it
- `beta`, which takes two inputs (transition rate & transversion rate), and allows for variation

Since it is preferable to have variable inputs in Bayesian Inference, the preference would be to use the `beta` input. In general, the beta input should be in the form `beta(ax, x)`, where `a` is the ts/tv ratio, and `x` represents how close to the ratio the data is. (Source 1)

Source 1: (From the MrBayes `help prset` page)
> If you think it is likely that the transition/transversion rate ratio is 2.0, you can use a prior of the type beta(2x,x), where x determines how strongly the prior is concentrated on tratio values near 2.0.

Therefore, the ratio is figured out as below:
- `beta(kappa, 1)` when `codon_kappa_style` is `CK_ONE_KAPPA` (kappa here represents the ts/tv rate ratio)
- `beta(kappa, 1)` when `codon_kappa_style` is `CK_ONE_KAPPA_TS` (kappa here represents the transition rate)
- `beta(1, kappa)` when `codon_kappa_style` is `CK_ONE_KAPPA_TV` (kappa here represents the transversion rate)
- `beta(kappa, kappa2)` when `codon_kappa_style` is `CK_TWO_KAPPA` (kappa here represents the transition rate, and kappa2 represents the transversion rate)

(Source: [Usage of Kappa and Kappa2 in Four Functions](https://github.com/iqtree/iqtree2/blob/master/model/modelcodon.cpp#L845-L961))

### DN/DS Rate Ratio
`ModelCodon` stores the dn/ds rate ratio in `omega`. Similar to ts/tv, we do not have the non-synonymous rate and the synonymous rate individually.

MrBayes, again similar to ts/tv, has two possible inputs for `omegapr`.
- `fixed`, takes one input (the dn/ds rate ratio), fixes it
- `dirichlet`, takes two inputs (non-synonymous rate and the synonymous rate), allows for change.

However, as we don't know the rates themselves, the output would simply be the first case in the ts/tv ratio calculation: `dirichlet(omega, 1)`.

### State Frequencies
This is simply retrieved from `state_freq`. However, the implementation also skips indices of `state_freq` where `phylo_tree->aln->isStopCodon(i)` returns true.

### Omega Variation
Since IQTree has no values for Omega Variation (which variates the ds/dt ratio across codons, based on how they affect fitness), this has been set to `equal`. The user can still change this value themselves if they wish to do so.

This could be improved in the future, so that it and its other priors, are sourced from the gamma distribution.

### Rate Heterogeneity Modifiers
MrBayes does not support `+G` or `+I` (or `+R`, although it doesn't support that in any sequence type) for Codon Models. This has been excluded, and a warning printed to the file and log.

### Rate Matrix
This has also been discarded, as there is no input in MrBayes for the rate matrix.

## Empirical Model Output
MrBayes does not support Empirical Codon Models, so when such a model is being used (or a mixture of Empirical + Mechanistic), a warning is printed to the log and file. However, a model is still outputted, with `nst = 1`, no kappa/omega values, and the provided state frequencies.

## Codon Codes
Whilst IQTree uses Number IDs for its Codon Codes (CODON1, CODON2, etc.), MrBayes uses Text IDs. (`vertmt`, `invermt`, etc.) There is no clear documentation or description for most of the models, but below shows the final table to transfer from IQTree Codon Codes to MrBayes Codon Codes.

An `XXX` in the MrBayes column represents a code that MrBayes does not support.

| IQTree  | MrBayes    |
| ------- | ---------- |
| CODON1  | universal  |
| CODON2  | vertmt     |
| CODON3  | yeast      |
| CODON4  | mycoplasma |
| CODON5  | invermt    |
| CODON6  | ciliate    |
| CODON9  | echinoderm |
| CODON10 | euplotid   |
| CODON11 | universal  |
| CODON12 | XXX        |
| CODON13 | XXX        |
| CODON14 | XXX        |
| CODON16 | XXX        |
| CODON21 | XXX        |
| CODON22 | XXX        |
| CODON23 | XXX        |
| CODON24 | XXX        |
| CODON25 | XXX        |

If a code is used that MrBayes does not support, it defaults to the universal code, and prints an error to the log and file.

## Other Changes
The main changes were: (compared with Previous Two PRs)
- Changing the indentation of warnings in the output file to match the indentation of the model parameters
- Changing the `printMrBayesModelText` in `ModelSubst` and child classes to not include the `RateHeterogeneity` parameter, instead having that accessed via `phylo_tree->getRate()`
- Improving the initial warning in the output files

## Testing
The base cases, and some edge cases, have been tested across all data types and some models. The test case simply was to check the presence of the warnings, and that the output files import without errors into MrBayes.

However, further tests may need to be conducted on whether the input values into MrBayes produce an acceptable and reliable result.