### PR TITLE
Fix auto-detection of binary data

### DIFF
--- a/alignment/alignment.cpp
+++ b/alignment/alignment.cpp
@@ -1335,7 +1335,7 @@ SeqType Alignment::detectSequenceType(StrVector &sequences) {
     }
     if (((double)num_nuc) / num_ungap > 0.9)
         return SEQ_DNA;
-    if (((double)num_bin) / num_ungap > 0.9)
+    if (num_bin == num_ungap) // For binary data, only 0, 1, ?, -, . can occur
         return SEQ_BINARY;
     if (((double)num_alpha + num_nuc) / num_ungap > 0.9)
         return SEQ_PROTEIN;


### PR DESCRIPTION
This PR fixes issue #344 by employing a stricter criterion for distinguishing data of type `BIN` from those of type `MORPH`.