### PR TITLE
Add GitHub Actions workflow for Claude Assistant

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,25 @@
+name: Claude Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned, labeled]
+  discussion_comment:
+    types: [created]
+
+jobs:
+  claude-roblanf:
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'issue_comment' && github.event.comment.user.login == 'roblanf') ||
+      (github.event_name == 'pull_request_review_comment' && github.event.comment.user.login == 'roblanf') ||
+      (github.event_name == 'issues' && github.actor == 'roblanf') ||
+      (github.event_name == 'discussion_comment' && github.event.comment.user.login == 'roblanf')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_ROBLANF }}


### PR DESCRIPTION
First attempt to enable Claude. Should be limited to just me posting. 

to add your own ability to call claude, get your own API key, add it to the org-level secrets, then duplicate the claude-roblanf block, but using your own API key.